### PR TITLE
Replace StopInteration with return in generator

### DIFF
--- a/transformer-cnn.py
+++ b/transformer-cnn.py
@@ -293,7 +293,7 @@ def data_generator(ds):
       if len(data) > 0:
          yield gen_data(data);
          data = [];
-      raise StopIteration();
+      return
 
 def buildNetwork():
 


### PR DESCRIPTION
According to this [discussion](https://stackoverflow.com/questions/14183803/what-is-the-difference-between-raise-stopiteration-and-a-return-statement-in-gen), the `return` method is more pythonic. Actually with `raise StopIteration`, I could not run through the code.